### PR TITLE
More options for diet-static..

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = function(options){
 			path: '',
 			index: true,
 			showScriptName: true,
-			defaultScript: 'html'
+			defaultScript: 'html',
+			cache: 'public'
 		};
 
 		setOptions(options, opt);
@@ -39,7 +40,7 @@ module.exports = function(options){
 				if(!error){
 					$.header('Last-Modified', stats.mtime)
 					$.header('Expires', new Date(new Date().getTime() + 604800000).toUTCString())
-					$.header('Cache-Control', 'public')
+					$.header('Cache-Control', opt.cache)
 					var modified_since = new Date($.headers['if-modified-since']).getTime();
 					var last_modified = new Date(stats.mtime).getTime()
 					if(!$.headers['if-modified-since'] || last_modified > modified_since){

--- a/index.js
+++ b/index.js
@@ -7,16 +7,34 @@ var zlib = require('zlib');
 var cache = {}
 module.exports = function(options){
 	return function($){
-		var pathname = $.url.pathname;
+		/**
+		 * Define default options
+		 * however, the path must be set because there is no way that $ could get the root path of the application
+		 *
+		 * @path            String   The path where the static files are
+		 * @index           Boolean  Set if must search for index file if this is not specified in url
+		 * @showScriptName  Boolean  Set if extensions must be writen in url, if not then @defaultScript is concatenated
+		 * @defaultScript   String   The extension to be concatenated if @showScriptName is false
+		 */
+		var opt = {
+			path: '',
+			index: true,
+			showScriptName: true,
+			defaultScript: 'html'
+		};
+
+		setOptions(options, opt);
+
+		var pathname = parseUrl($.url.pathname, opt);
 		var mimeType = mime.lookup(pathname);
 		var extension = path.extname(pathname);
-		
+
 		// if no route was specified there is an extension and mimeType is not binary
 		if(extension){
 			// set header
 			$.header('Content-Type', mimeType);
 			$.status(200);
-			var source = options.path + $.url.pathname;
+			var source = opt.path + pathname;
 			fs.stat(source, function (error, stats) {
 				if(!error){
 					$.header('Last-Modified', stats.mtime)
@@ -71,4 +89,36 @@ module.exports = function(options){
 			$.return();
 		}
 	}
+}
+
+function setOptions(opt, def){
+	for(p in opt){
+		def[p] = opt[p];
+	}
+
+	return def;
+}
+
+function parseUrl(url, options){
+	var urlTotal = url;
+	var script = '.' + options.defaultScript;
+
+	if(!options.index){
+		if(path.extname(urlTotal) == ''){
+			if(path.basename(urlTotal, script) == 'index')
+				urlTotal = urlTotal + script;
+
+			else
+				urlTotal = path.join(urlTotal, 'index') + script;
+		}
+	}
+
+	else{
+		if(urlTotal.length > 1){
+			if(!options.showScriptName && path.extname(urlTotal).length == 0)
+				urlTotal = urlTotal + script;
+		}
+	}
+
+	return urlTotal;
 }


### PR DESCRIPTION
there are default options which can be changed..

new options (Optional):
index: [Boolean] Set if must search for index file if this is not specified in url (default: true)
showScriptName: [Boolean] Set if extensions must be writen in url, if not then @defaultScript is concatenated (default: true)
defaultScript: [String] The extension to be concatenated if @showScriptName is false (default: 'html')
## **Example**

``` javascript
// Initialize Server
var server = require('diet') // Require Diet
var app = server()           // Create App
app.listen(8000)             // Configure Domain

// Require diet-static
var static = require('diet-static')({
    path: app.path + '/static',
    index: false,                   // ignore index in url "http://localhost/" will search for "http://localhost/index"
    showScriptName: false, // ignore the extension expecified in "defaultScript", example "index.html"
    defaultScript: 'html'        // whenever "showScriptName" is false, this is the extension for index
})

// Attach static as a global footer
app.footer(static);
```
